### PR TITLE
Make dirname and --current_dir mutually exclusive

### DIFF
--- a/scripts/init_latex.py
+++ b/scripts/init_latex.py
@@ -54,16 +54,16 @@ def argparser():
     """Argument parser."""
     description = "Initialise the main files needed in a LaTeX article."
     parser = argparse.ArgumentParser(description=description)
-
+    
+    group=parser.add_mutually_exclusive_group(required=True)
     dirname = ("Name of the directory in which the LaTeX files will be"
                + " generated into.")
-    parser.add_argument("dirname", metavar="directory name", type=str,
-                        help=dirname)
-    
+    group.add_argument("dirname", metavar="directory name", type=str,
+                       nargs='?', help=dirname)
     current_dir = ("If this flag is set, the files are generated into "
-                   "the current working directory.")
-    parser.add_argument("--current_dir", action="store_true",
-                        help=current_dir)
+                 + "the current working directory.")
+    group.add_argument("--current_dir", action="store_true",
+                       help=current_dir)
     
     # Document-specific stuff.
     author = "Author of the LaTeX article."

--- a/scripts/init_latex.py
+++ b/scripts/init_latex.py
@@ -55,13 +55,13 @@ def argparser():
     description = "Initialise the main files needed in a LaTeX article."
     parser = argparse.ArgumentParser(description=description)
     
-    group=parser.add_mutually_exclusive_group(required=True)
+    group = parser.add_mutually_exclusive_group(required=True)
     dirname = ("Name of the directory in which the LaTeX files will be"
                + " generated into.")
     group.add_argument("dirname", metavar="directory name", type=str,
                        nargs='?', help=dirname)
     current_dir = ("If this flag is set, the files are generated into "
-                 + "the current working directory.")
+                   + "the current working directory.")
     group.add_argument("--current_dir", action="store_true",
                        help=current_dir)
     


### PR DESCRIPTION
Initlatex no longer requires a directory name if the
--current_dir flag is set. The two arguments are now
mutually exclusive, but one must be set.